### PR TITLE
Fix error when running hw init + update install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ hw is a toolkit for managing your homework as a hacker, in the true sense of the
 
 hw is how I'm slowly replacing monoliths like Google Drive with lightweight hackable tools like git and vim. Join me on my journey :)
 
+# Install
+hw requires node 0.10+ and git.
+
+    $ git clone https://github.com/bobbybee/hw && cd hw && npm install -g
+
 # Usage
 Below is a listing of a few common tasks you might use hw for.
-
-## Install
-
-    $ git clone https://github.com/bobbybee/hw && cd hw && sudo npm install -g
 
 ## New Repo
 

--- a/current-config.js
+++ b/current-config.js
@@ -27,6 +27,7 @@
  * this is dependent on phantomjs!
  */
 
+var fs = require("fs");
 var defaultConfig = require("./config.js");
 
 function failMessage() {


### PR DESCRIPTION
Hi Alyssa,

I had a bug when running `hw init`, node wasn't able to find a definition to `fs`. So in order to fix this problem, I added `var fs = require('fs');` at the top of `current-config.js`. It works great now.

I also updated the install instructions in the README with required node version (I tried all the main commands on node 0.10). Furthermore, I removed the `sudo` before `npm install -g` because it really depend on your configuration. For example, running `sudo npm -g` if you installed node using [nvm](https://github.com/creationix/nvm) won't work.

Also, this [script](https://github.com/glenpike/npm-g_nosudo) allow you to fix the problem where you want to stop using `sudo` for `npm -g`

Finally, I've spotted some trailing whitespaces in the code. Is it okay if I submit another pull request with those whitespaces removed?

Let me know what you think!